### PR TITLE
Update views.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 
 1.0a1 (unreleased)
 ------------------
+- python38+ fix
 
 - Initial release.
   []

--- a/src/plone/instanceprofiling/setuphandlers.py
+++ b/src/plone/instanceprofiling/setuphandlers.py
@@ -15,7 +15,7 @@ def post_install(context):
     for cnt in range(400):
         content_structure.append(
             {
-                "type": "Document",
+                "@type": "Document",
                 "title": "Document " + str(cnt),
                 "data": {
                     "description": "Some thing."

--- a/src/plone/instanceprofiling/views.py
+++ b/src/plone/instanceprofiling/views.py
@@ -21,13 +21,13 @@ class ContentUrlsView(BrowserView):
 class ContentTimeView(BrowserView):
 
     def __call__(self):
-        clock_s = time.clock()
+        clock_s = time.process_time()
         real_s = time.time()
 
         dummy = self.context()
 
         clock_e = time.clock()
-        real_e = time.time()
+        real_e = time.process_time()
 
         ret = {'clock': clock_e - clock_s, 'real': real_e - real_s}
 


### PR DESCRIPTION
time.clock() was removed in python3.8 and here we want the cpu time.